### PR TITLE
Enable Nodify plugin host validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,4 +28,4 @@ jobs:
         run: msbuild src/Storylines.sln /p:Platform=x64 /p:Configuration=Debug
 
       - name: Run tests
-        run: dotnet test src/Storylines.Tests/Storylines.Tests.csproj --platform x64 --no-build --verbosity normal
+        run: dotnet test src/Storylines.Tests/Storylines.Tests.csproj --no-build --verbosity normal

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ msbuild src/Storylines.sln /p:Platform=x64 /p:Configuration=Debug /t:Restore
 msbuild src/Storylines.sln /p:Platform=x64 /p:Configuration=Debug
 
 # Run tests
-dotnet test src/Storylines.Tests/Storylines.Tests.csproj --platform x64
+dotnet test src/Storylines.Tests/Storylines.Tests.csproj
 ```
 
 If you are working in the multi-repo private-plugin workspace, prefer `../storylines-dialogue-plugin/scripts/Invoke-StorylinesBuild.ps1` because it resolves `MSBuild.exe` explicitly.

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "9.0.313",
-    "rollForward": "latestFeature"
+    "rollForward": "latestMajor"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,4 +1,7 @@
 {
+  "msbuild-sdks": {
+    "Uno.Sdk": "6.6.29"
+  },
   "sdk": {
     "version": "9.0.313",
     "rollForward": "latestMajor"

--- a/src/Storylines/App.xaml.cs
+++ b/src/Storylines/App.xaml.cs
@@ -282,6 +282,12 @@ public partial class App : Application
 
     private void App_UnhandledException(object sender, Microsoft.UI.Xaml.UnhandledExceptionEventArgs e)
     {
+#if DEBUG
+        var details = e.Exception?.ToString() ?? e.Message;
+        System.IO.File.WriteAllText(
+            System.IO.Path.Combine(System.IO.Path.GetTempPath(), "Storylines-unhandled.txt"),
+            details);
+#endif
         App.TryGetService<ITelemetryService>()?.TrackUnhandledException(e.Exception, e.Message);
 
         e.Handled = true;

--- a/src/Storylines/App.xaml.cs
+++ b/src/Storylines/App.xaml.cs
@@ -182,8 +182,10 @@ public partial class App : Application
             ThemeSettings.Initialize();
             if (openLoadDialog)
                 GetService<IDialogService>().OpenLoadDialogue();
+#if !DEBUG
             MicrosoftStoreFunctions.InitializeReview();
             ObserveBackgroundOperation(MicrosoftStoreFunctions.CheckForNewUpdateAvailableAsync(), "Failed to check for updates");
+#endif
             context.IsInitialized = true;
         }
 


### PR DESCRIPTION
## Summary

Build and debug support needed to validate the private Nodify.Uno dialogue plugin against the legacy .NET 9 Storylines host.

## Changes

- Allow the pinned .NET 9 project to roll forward to the installed newer SDK
- Map the referenced Uno project to the repository's Uno.Sdk version
- Skip Microsoft Store review/update probes in Debug builds only
- Capture Debug XAML unhandled exceptions to a temporary diagnostic file
- Run CI tests against the AnyCPU test output produced by the solution build

## Validation

- GitHub `Build & Test` workflow passes
- Full x64 Debug host build succeeds with the private plugin and Nodify.Uno's .NET 9 Windows target
- Storylines unit tests pass through the corrected CI command

Release behavior and the .NET 9 target framework are unchanged.