### PR TITLE
Update CI actions for Node 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,10 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       - name: Restore NuGet packages
         run: msbuild src/Storylines.sln /p:Platform=x64 /p:Configuration=Debug /t:Restore


### PR DESCRIPTION
## Summary

Updates the Storylines `Build & Test` workflow to Node 24-compatible action majors:

- `actions/checkout@v7`
- `microsoft/setup-msbuild@v3`

This removes the post-merge Node 20 deprecation warning without changing build or test commands.