### PR TITLE
Add Debug-only in-process E2E hook

### DIFF
--- a/src/Storylines/App.xaml.cs
+++ b/src/Storylines/App.xaml.cs
@@ -53,10 +53,23 @@ public partial class App : Application
         var pendingItem = GetActivatedStorageItem(AppInstance.GetCurrent().GetActivatedEventArgs());
         var windowManager = Services.GetRequiredService<IWindowManager>();
         var context = windowManager.CreateDocumentWindow(pendingItem, "OnLaunched");
+#if DEBUG
+        var runApplicationE2E = Testing.ApplicationE2EHook.HasPendingRequest;
+#else
+        const bool runApplicationE2E = false;
+#endif
 
         await windowManager.RunAsync(context, async () =>
         {
-            await ActivateAsync(context, "launch", !hasRecoveryData && pendingItem is null);
+            await ActivateAsync(context, "launch", !runApplicationE2E && !hasRecoveryData && pendingItem is null);
+
+#if DEBUG
+            if (runApplicationE2E)
+            {
+                await Testing.ApplicationE2EHook.RunAsync(context);
+                return;
+            }
+#endif
 
             if (hasRecoveryData)
             {

--- a/src/Storylines/Testing/ApplicationE2EHook.cs
+++ b/src/Storylines/Testing/ApplicationE2EHook.cs
@@ -1,0 +1,32 @@
+#if DEBUG
+#nullable enable
+using System;
+using System.Threading.Tasks;
+using Storylines.Services;
+
+namespace Storylines.Testing;
+
+internal static partial class ApplicationE2EHook
+{
+    private static readonly Func<bool>? HasPendingRequestCallback;
+    private static readonly Func<WindowContext, Task>? RunAsyncCallback;
+
+    static ApplicationE2EHook()
+    {
+        Func<bool>? hasPendingRequest = null;
+        Func<WindowContext, Task>? runAsync = null;
+        Configure(ref hasPendingRequest, ref runAsync);
+        HasPendingRequestCallback = hasPendingRequest;
+        RunAsyncCallback = runAsync;
+    }
+
+    public static bool HasPendingRequest => HasPendingRequestCallback?.Invoke() == true;
+
+    public static Task RunAsync(WindowContext context) =>
+        RunAsyncCallback?.Invoke(context) ?? Task.CompletedTask;
+
+    static partial void Configure(
+        ref Func<bool>? hasPendingRequest,
+        ref Func<WindowContext, Task>? runAsync);
+}
+#endif


### PR DESCRIPTION
## Summary

Adds a generic Debug-only in-process E2E hook to Storylines. The hook is inert unless a private plugin supplies the partial implementation and explicitly opts in at build time.

## Safety

- Compile-time removed from Release
- No request-file I/O in normal Debug builds
- Existing launch/recovery behavior is unchanged when no E2E request is active
- Uses the existing `WindowContext` and scoped services

## Consumer

The private dialogue plugin uses this hook to run real-host Nodify acceptance without traversing the legacy host UI Automation provider, which crashes in `Microsoft.UI.Xaml.dll` with `RPC_E_WRONG_THREAD`.

## Validation

- Normal x64 Debug host build succeeds with the private plugin and no E2E opt-in
- `StorylinesDialogueE2E=true` is rejected outside Debug by the plugin contract
- Full in-process dialogue acceptance passes repeatedly